### PR TITLE
Terminate remaining standalone pods

### DIFF
--- a/internal/service/scaling.go
+++ b/internal/service/scaling.go
@@ -16,25 +16,28 @@ const (
 	timeInterval = time.Second * 2
 )
 
-func (s *Service) ScaleDownGroup(groupNumber int) error {
-	var resources []K8sResource
+func (s *Service) scaleDownGroup(groupNumber int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var resources []k8sResource
 	var found bool
-	if resources, found = s.StartUpOrder[groupNumber]; !found {
-		return fmt.Errorf("ScaleDownGroup %d not found in the StartUpOrder map", groupNumber)
+	if resources, found = s.startUpOrder[groupNumber]; !found {
+		return fmt.Errorf("scaleDownGroup %d not found in the startUpOrder map", groupNumber)
 	}
 
 	for _, resource := range resources {
-		if resource.Type == "deployment" {
+		if resource.ResourceType == "deployment" {
 			// Use a retry function to handle conflicts on updates from concurrent changes
 			// https://github.com/kubernetes/client-go/tree/master/examples/create-update-delete-deployment
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := s.Conf.K8sClient.AppsV1().Deployments(resource.Namespace).Get(context.TODO(), resource.Name, metav1.GetOptions{})
+				result, getErr := s.conf.K8sClient.AppsV1().Deployments(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
 				if getErr != nil {
 					return getErr
 				}
 
 				if *result.Spec.Replicas == 0 {
-					log.Warn("The workload has already been scaled to zero. Skipping", "type", resource.Type, "resource", result.Name, "namespace", result.Namespace)
+					log.Warn("The workload has already been scaled to zero. Skipping", "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -48,26 +51,26 @@ func (s *Service) ScaleDownGroup(groupNumber int) error {
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
-				_, updateErr := s.Conf.K8sClient.AppsV1().Deployments(resource.Namespace).Update(context.TODO(), result, metav1.UpdateOptions{})
+				_, updateErr := s.conf.K8sClient.AppsV1().Deployments(resource.Namespace).Update(ctx, result, metav1.UpdateOptions{})
 				return updateErr
 			})
 			if retryErr != nil {
-				return fmt.Errorf("failed to update deployment %s in namespace %s: %w", resource.Name, resource.Namespace, retryErr)
+				return fmt.Errorf("failed to update deployment %s in Namespace %s: %w", resource.Name, resource.Namespace, retryErr)
 			}
-			log.Debug("Deployment scaled down", "deployment", resource.Name, "namespace", resource.Namespace)
+			log.Debug("Deployment scaled down", "deployment", resource.Name, "Namespace", resource.Namespace)
 		}
 
-		if resource.Type == "statefulset" {
+		if resource.ResourceType == "statefulset" {
 			// Use a retry function to handle conflicts on updates from concurrent changes
 			// https://github.com/kubernetes/client-go/tree/master/examples/create-update-delete-deployment
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := s.Conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Get(context.TODO(), resource.Name, metav1.GetOptions{})
+				result, getErr := s.conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
 				if getErr != nil {
 					return getErr
 				}
 
 				if *result.Spec.Replicas == 0 {
-					log.Warn("The workload has already been scaled to zero. Skipping", "type", resource.Type, "resource", result.Name, "namespace", result.Namespace)
+					log.Warn("The workload has already been scaled to zero. Skipping", "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -81,13 +84,13 @@ func (s *Service) ScaleDownGroup(groupNumber int) error {
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
-				_, updateErr := s.Conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Update(context.TODO(), result, metav1.UpdateOptions{})
+				_, updateErr := s.conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Update(ctx, result, metav1.UpdateOptions{})
 				return updateErr
 			})
 			if retryErr != nil {
-				return fmt.Errorf("failed to update %s %s in namespace %s: %w", resource.Type, resource.Name, resource.Namespace, retryErr)
+				return fmt.Errorf("failed to update %s %s in Namespace %s: %w", resource.ResourceType, resource.Name, resource.Namespace, retryErr)
 			}
-			log.Debug("Statefulset scaled down", "statefulset", resource.Name, "namespace", resource.Namespace)
+			log.Debug("Statefulset scaled down", "statefulset", resource.Name, "Namespace", resource.Namespace)
 		}
 	}
 
@@ -98,7 +101,7 @@ func (s *Service) ScaleDownGroup(groupNumber int) error {
 	return nil
 }
 
-func (s *Service) waitForPodTermination(resources []K8sResource) error {
+func (s *Service) waitForPodTermination(resources []k8sResource) error {
 	interval := time.Tick(timeInterval)
 	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
 	defer cancelCtx()
@@ -114,20 +117,20 @@ func (s *Service) waitForPodTermination(resources []K8sResource) error {
 				// If we range over the slice, we are working with copies only, so can't update the podsTerminated correctly
 				r := &resources[i]
 
-				log.Debug("Finding non-terminated pods", "type", r.Type, "resource", r.Name, "namespace", r.Namespace, "selector", r.Selector)
+				log.Debug("Finding non-terminated pods", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace, "selector", r.Selector)
 
-				pods, err := s.Conf.K8sClient.CoreV1().Pods(r.Namespace).List(ctx, metav1.ListOptions{LabelSelector: r.Selector})
+				pods, err := s.conf.K8sClient.CoreV1().Pods(r.Namespace).List(ctx, metav1.ListOptions{LabelSelector: r.Selector})
 				if err != nil {
 					return fmt.Errorf("listing pods: %w", err)
 				}
 
 				if len(pods.Items) == 0 {
-					log.Debug("Pods have been terminated", "resource", r.Name, "namespace", r.Namespace)
+					log.Debug("Pods have been terminated", "resource", r.Name, "Namespace", r.Namespace)
 					r.podsTerminated = true
 					continue
 				}
 
-				log.Debug("Pods still running", "resource", r.Name, "namespace", r.Namespace, "podCount", len(pods.Items))
+				log.Debug("Pods still running", "resource", r.Name, "Namespace", r.Namespace, "podCount", len(pods.Items))
 			}
 
 		case <-ctx.Done():
@@ -136,7 +139,7 @@ func (s *Service) waitForPodTermination(resources []K8sResource) error {
 	}
 }
 
-func podsStillRunning(resources []K8sResource) bool {
+func podsStillRunning(resources []k8sResource) bool {
 	var runningPods bool
 	for _, r := range resources {
 		if r.podsTerminated == false {
@@ -149,26 +152,29 @@ func podsStillRunning(resources []K8sResource) bool {
 
 func int32Ptr(i int32) *int32 { return &i }
 
-func (s *Service) ScaleUpGroup(groupNumber int) error {
-	var resources []K8sResource
+func (s *Service) scaleUpGroup(groupNumber int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var resources []k8sResource
 	var found bool
-	if resources, found = s.StartUpOrder[groupNumber]; !found {
-		return fmt.Errorf("ScaleUpGroup %d not found in the StartUpOrder map", groupNumber)
+	if resources, found = s.startUpOrder[groupNumber]; !found {
+		return fmt.Errorf("scaleUpGroup %d not found in the startUpOrder map", groupNumber)
 	}
 
 	for _, resource := range resources {
-		if resource.Type == "deployment" {
+		if resource.ResourceType == "deployment" {
 			// Use a retry function to handle conflicts on updates from concurrent changes
 			// https://github.com/kubernetes/client-go/tree/master/examples/create-update-delete-deployment
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := s.Conf.K8sClient.AppsV1().Deployments(resource.Namespace).Get(context.TODO(), resource.Name, metav1.GetOptions{})
+				result, getErr := s.conf.K8sClient.AppsV1().Deployments(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
 				if getErr != nil {
 					return fmt.Errorf("getting deployment %s: %w", result.Name, getErr)
 				}
 
 				replicasRaw, found := result.Annotations[OriginalReplicasAnnotationKey]
 				if !found {
-					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.Type, "resource", result.Name, "namespace", result.Namespace)
+					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -184,27 +190,27 @@ func (s *Service) ScaleUpGroup(groupNumber int) error {
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
-				_, updateErr := s.Conf.K8sClient.AppsV1().Deployments(resource.Namespace).Update(context.TODO(), result, metav1.UpdateOptions{})
+				_, updateErr := s.conf.K8sClient.AppsV1().Deployments(resource.Namespace).Update(ctx, result, metav1.UpdateOptions{})
 				return updateErr
 			})
 			if retryErr != nil {
-				return fmt.Errorf("failed to update deployment %s in namespace %s: %w", resource.Name, resource.Namespace, retryErr)
+				return fmt.Errorf("failed to update deployment %s in Namespace %s: %w", resource.Name, resource.Namespace, retryErr)
 			}
-			log.Debug("Deployment scaled up", "deployment", resource.Name, "namespace", resource.Namespace)
+			log.Debug("Deployment scaled up", "deployment", resource.Name, "Namespace", resource.Namespace)
 		}
 
-		if resource.Type == "statefulset" {
+		if resource.ResourceType == "statefulset" {
 			// Use a retry function to handle conflicts on updates from concurrent changes
 			// https://github.com/kubernetes/client-go/tree/master/examples/create-update-delete-deployment
 			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := s.Conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Get(context.TODO(), resource.Name, metav1.GetOptions{})
+				result, getErr := s.conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
 				if getErr != nil {
 					return fmt.Errorf("getting statefulset %s: %w", result.Name, getErr)
 				}
 
 				replicasRaw, found := result.Annotations[OriginalReplicasAnnotationKey]
 				if !found {
-					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.Type, "resource", result.Name, "namespace", result.Namespace)
+					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -220,13 +226,13 @@ func (s *Service) ScaleUpGroup(groupNumber int) error {
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
-				_, updateErr := s.Conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Update(context.TODO(), result, metav1.UpdateOptions{})
+				_, updateErr := s.conf.K8sClient.AppsV1().StatefulSets(resource.Namespace).Update(ctx, result, metav1.UpdateOptions{})
 				return updateErr
 			})
 			if retryErr != nil {
-				return fmt.Errorf("failed to update %s %s in namespace %s: %w", resource.Type, resource.Name, resource.Namespace, retryErr)
+				return fmt.Errorf("failed to update %s %s in Namespace %s: %w", resource.ResourceType, resource.Name, resource.Namespace, retryErr)
 			}
-			log.Debug("Statefulset scaled up", "statefulset", resource.Name, "namespace", resource.Namespace)
+			log.Debug("Statefulset scaled up", "statefulset", resource.Name, "Namespace", resource.Namespace)
 		}
 	}
 
@@ -237,7 +243,7 @@ func (s *Service) ScaleUpGroup(groupNumber int) error {
 	return nil
 }
 
-func (s *Service) waitForPodsReady(resources []K8sResource) error {
+func (s *Service) waitForPodsReady(resources []k8sResource) error {
 	interval := time.Tick(timeInterval)
 	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
 	defer cancelCtx()
@@ -253,38 +259,38 @@ func (s *Service) waitForPodsReady(resources []K8sResource) error {
 				// If we range over the slice, we are working with copies only, so can't update the podsTerminated correctly
 				r := &resources[i]
 
-				if r.Type == "deployment" {
-					log.Debug("Checking if pods are updated and ready", "type", r.Type, "resource", r.Name, "namespace", r.Namespace)
-					deployment, err := s.Conf.K8sClient.AppsV1().Deployments(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
+				if r.ResourceType == "deployment" {
+					log.Debug("Checking if pods are updated and ready", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace)
+					deployment, err := s.conf.K8sClient.AppsV1().Deployments(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
 					if err != nil {
-						return fmt.Errorf("getting deloyment %s in namespace %s: %w", r.Name, r.Namespace, err)
+						return fmt.Errorf("getting deloyment %s in Namespace %s: %w", r.Name, r.Namespace, err)
 					}
 					if deployment.Status.AvailableReplicas == *deployment.Spec.Replicas &&
 						deployment.Status.UpdatedReplicas == *deployment.Spec.Replicas &&
 						deployment.Status.ReadyReplicas == *deployment.Spec.Replicas &&
 						deployment.Status.ObservedGeneration >= deployment.Generation {
 						r.podsUpdatedAndReady = true
-						log.Debug("Deployment ready", "type", r.Type, "resource", r.Name, "namespace", r.Namespace)
+						log.Debug("Deployment ready", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace)
 					}
 					continue
 				}
-				if r.Type == "statefulset" {
-					log.Debug("Checking if pods are updated and ready", "type", r.Type, "resource", r.Name, "namespace", r.Namespace)
-					statefulset, err := s.Conf.K8sClient.AppsV1().StatefulSets(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
+				if r.ResourceType == "statefulset" {
+					log.Debug("Checking if pods are updated and ready", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace)
+					statefulset, err := s.conf.K8sClient.AppsV1().StatefulSets(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
 					if err != nil {
-						return fmt.Errorf("getting statefulset %s in namespace %s: %w", r.Name, r.Namespace, err)
+						return fmt.Errorf("getting statefulset %s in Namespace %s: %w", r.Name, r.Namespace, err)
 					}
 					if statefulset.Status.AvailableReplicas == *statefulset.Spec.Replicas &&
 						statefulset.Status.UpdatedReplicas == *statefulset.Spec.Replicas &&
 						statefulset.Status.ReadyReplicas == *statefulset.Spec.Replicas &&
 						statefulset.Status.ObservedGeneration >= statefulset.Generation {
 						r.podsUpdatedAndReady = true
-						log.Debug("Statefulset ready", "type", r.Type, "resource", r.Name, "namespace", r.Namespace)
+						log.Debug("Statefulset ready", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace)
 					}
 					continue
 				}
 
-				return fmt.Errorf("expected 'deployment' or 'statefulset' type, but got '%s'", r.Type)
+				return fmt.Errorf("expected 'deployment' or 'statefulset' type, but got '%s'", r.ResourceType)
 			}
 
 		case <-ctx.Done():
@@ -293,7 +299,7 @@ func (s *Service) waitForPodsReady(resources []K8sResource) error {
 	}
 }
 
-func podsUpdatedAndReady(resources []K8sResource) bool {
+func podsUpdatedAndReady(resources []k8sResource) bool {
 	podsReady := true
 	for _, r := range resources {
 		if r.podsUpdatedAndReady == false {
@@ -302,4 +308,29 @@ func podsUpdatedAndReady(resources []K8sResource) bool {
 	}
 
 	return podsReady
+}
+
+func (s *Service) terminateStandalonePods() error {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
+	defer cancelCtx()
+
+	namespaces, err := s.conf.K8sClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing namespaces: %w", err)
+	}
+	for _, ns := range namespaces.Items {
+		pods, err := s.conf.K8sClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("listing pods in Namespace %s: %w", ns.Name, err)
+		}
+
+		for _, pod := range pods.Items {
+			log.Info("Terminating remaining pod", "pod", pod.Name, "Namespace", pod.Namespace)
+			if err = s.conf.K8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+				return fmt.Errorf("deleting pod %s in Namespace %s: %w", pod.Name, pod.Namespace, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/service/startupOrder_test.go
+++ b/internal/service/startupOrder_test.go
@@ -14,7 +14,7 @@ import (
 func Test_BuildStartUpOrder(t *testing.T) {
 	type fields struct {
 		Conf         config.Config
-		StartUpOrder StartUpOrder
+		StartUpOrder startUpOrder
 	}
 	tests := []struct {
 		name                string
@@ -106,17 +106,17 @@ func Test_BuildStartUpOrder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{
-				Conf:         tt.fields.Conf,
-				StartUpOrder: tt.fields.StartUpOrder,
+				conf:         tt.fields.Conf,
+				startUpOrder: tt.fields.StartUpOrder,
 			}
-			err := s.BuildStartUpOrder()
+			err := s.buildStartUpOrder()
 			if tt.wantErr {
 				assert.Error(t, err, "Expected error in test case: %s", tt.name)
 			} else {
 				assert.NoError(t, err, "Unexpected error in test case: %s", tt.name)
 			}
 
-			assert.Equal(t, tt.expectedNumOfGroups, len(s.StartUpOrder), "Unexpected number of startup groups in test case: %s", tt.name)
+			assert.Equal(t, tt.expectedNumOfGroups, len(s.startUpOrder), "Unexpected number of startup groups in test case: %s", tt.name)
 
 		})
 	}

--- a/manifests/standalone-pod.yaml
+++ b/manifests/standalone-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: standalone-pod
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.27-alpine
+      ports:
+        - containerPort: 80


### PR DESCRIPTION
- Terminate the remaining pods once the deploymentset/statefulelset pods have been terminated in order
- Only export the structs and fields which are required for better encapsulation
- Set contexts for all K8s CRUD calls for timeouts