### PR TITLE
Pass local kube context if running locally

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,15 +2,15 @@ package config
 
 import (
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	log "log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"path/filepath"
 )
 
 type ScaleAction string

--- a/manifests/pdb.yaml
+++ b/manifests/pdb.yaml
@@ -1,0 +1,11 @@
+# Demonstrates that the PDB does not block the deployment from being scaled to zero by the API
+# PDB only consider voluntary type disruptions
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-without-annotation
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx-without-annotation


### PR DESCRIPTION
- When working locally instead of defaulting to the current kubeconfig context (which could be pointing to production) expect an envar explicitly defining the context
- Add a pod disruption budget to prove that it doesn't block the scale down operations