### PR TITLE
Suspend CronJobs Functionality

### DIFF
--- a/internal/service/cronjob.go
+++ b/internal/service/cronjob.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	log "log/slog"
+	"time"
+
+	"github.com/michaelprice232/eks-env-scaledown/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+func (s *Service) updateCronJobs() error {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
+	defer cancelCtx()
+
+	namespaces, err := s.conf.K8sClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing namespaces: %w", err)
+	}
+	for _, ns := range namespaces.Items {
+		cjs, err := s.conf.K8sClient.BatchV1().CronJobs(ns.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("listing CronJobs in Namespace %s: %w", ns.Name, err)
+		}
+
+		for _, cj := range cjs.Items {
+			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				result, getErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Get(ctx, cj.Name, metav1.GetOptions{})
+				if getErr != nil {
+					return getErr
+				}
+
+				if appNameLabel, found := result.Labels["app"]; found && appNameLabel == cronJobAppName {
+					log.Debug("Skipping CronJob as it matches the app label which manages this app", "CronJob", cj.Name, "namespace", cj.Namespace)
+					return nil
+				}
+
+				// Do not scale up anything that was previously scaled down
+				if s.conf.Action == config.ScaleUp {
+					if value, found := result.Annotations[cronJobWasDisabledAnnotationKey]; found && value == "yes" {
+						log.Warn("CronJob was previously disabled. Skipping", "CronJob", cj.Name, "namespace", cj.Namespace)
+						return nil
+					}
+					result.Spec.Suspend = boolPtr(false)
+				}
+
+				if s.conf.Action == config.ScaleDown {
+					if *result.Spec.Suspend == true {
+						log.Warn("CronJob is already disabled. Setting annotation for scaleup run", "CronJob", cj.Name, "namespace", cj.Namespace)
+						if result.Annotations == nil {
+							result.Annotations = make(map[string]string)
+						}
+						result.Annotations[cronJobWasDisabledAnnotationKey] = "yes"
+					}
+
+					result.Spec.Suspend = boolPtr(true)
+				}
+
+				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+
+				_, updateErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Update(ctx, result, metav1.UpdateOptions{})
+				return updateErr
+			})
+			if retryErr != nil {
+				return fmt.Errorf("updating CronJob %s in namespace %s: %w", cj.Name, cj.Namespace, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/service/scaledown.go
+++ b/internal/service/scaledown.go
@@ -41,8 +41,8 @@ func (s *Service) scaleDownGroup(groupNumber int) error {
 				}
 
 				result.Spec.Replicas = int32Ptr(0)
-				result.Annotations[OriginalReplicasAnnotationKey] = strconv.FormatInt(int64(resource.ReplicaCount), 10)
-				result.Annotations[UpdatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+				result.Annotations[originalReplicasAnnotationKey] = strconv.FormatInt(int64(resource.ReplicaCount), 10)
+				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
@@ -74,8 +74,8 @@ func (s *Service) scaleDownGroup(groupNumber int) error {
 				}
 
 				result.Spec.Replicas = int32Ptr(0)
-				result.Annotations[OriginalReplicasAnnotationKey] = strconv.FormatInt(int64(resource.ReplicaCount), 10)
-				result.Annotations[UpdatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+				result.Annotations[originalReplicasAnnotationKey] = strconv.FormatInt(int64(resource.ReplicaCount), 10)
+				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict

--- a/internal/service/scaleup.go
+++ b/internal/service/scaleup.go
@@ -31,9 +31,9 @@ func (s *Service) scaleUpGroup(groupNumber int) error {
 					return fmt.Errorf("getting deployment %s: %w", result.Name, getErr)
 				}
 
-				replicasRaw, found := result.Annotations[OriginalReplicasAnnotationKey]
+				replicasRaw, found := result.Annotations[originalReplicasAnnotationKey]
 				if !found {
-					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
+					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", originalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -44,8 +44,8 @@ func (s *Service) scaleUpGroup(groupNumber int) error {
 				replicas := int32(replica64)
 
 				result.Spec.Replicas = &replicas
-				delete(result.Annotations, OriginalReplicasAnnotationKey)
-				result.Annotations[UpdatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+				delete(result.Annotations, originalReplicasAnnotationKey)
+				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict
@@ -67,9 +67,9 @@ func (s *Service) scaleUpGroup(groupNumber int) error {
 					return fmt.Errorf("getting statefulset %s: %w", result.Name, getErr)
 				}
 
-				replicasRaw, found := result.Annotations[OriginalReplicasAnnotationKey]
+				replicasRaw, found := result.Annotations[originalReplicasAnnotationKey]
 				if !found {
-					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", OriginalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
+					log.Warn("NumReplicas Annotation key not set. The resource might have been created after the scaledown. Skipping", "key", originalReplicasAnnotationKey, "type", resource.ResourceType, "resource", result.Name, "Namespace", result.Namespace)
 					return nil
 				}
 
@@ -80,8 +80,8 @@ func (s *Service) scaleUpGroup(groupNumber int) error {
 				replicas := int32(replica64)
 
 				result.Spec.Replicas = &replicas
-				delete(result.Annotations, OriginalReplicasAnnotationKey)
-				result.Annotations[UpdatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+				delete(result.Annotations, originalReplicasAnnotationKey)
+				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
 
 				// RetryOnConflict expects the error to be returned unwrapped
 				// https://pkg.go.dev/k8s.io/client-go/util/retry@v0.33.0#RetryOnConflict

--- a/internal/service/startupOrder.go
+++ b/internal/service/startupOrder.go
@@ -44,17 +44,17 @@ func (s *Service) buildStartUpOrder() error {
 			Selector:     selector,
 		}
 
-		if orderKey, found := d.Annotations[StartupOrderAnnotationKey]; found {
+		if orderKey, found := d.Annotations[startupOrderAnnotationKey]; found {
 			so, err := strconv.Atoi(orderKey)
 			if err != nil {
-				log.Warn("Unable to parse the int from the startup order key. Assigning to default group", "deployment", d.Name, "Namespace", d.Namespace, "originalOrder", so, "key", StartupOrderAnnotationKey)
-				orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+				log.Warn("Unable to parse the int from the startup order key. Assigning to default group", "deployment", d.Name, "Namespace", d.Namespace, "originalOrder", so, "key", startupOrderAnnotationKey)
+				orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 				continue
 			}
 
 			if so > 99 {
 				log.Warn("startUpOrder number can only be from 0 to 99. Assigning to default group", "deployment", d.Name, "Namespace", d.Namespace, "originalOrder", so)
-				orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+				orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 				continue
 			}
 
@@ -62,7 +62,7 @@ func (s *Service) buildStartUpOrder() error {
 			continue
 		}
 		// Assign to the default group which starts up last if not set
-		orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+		orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 	}
 
 	// Statefulsets
@@ -84,17 +84,17 @@ func (s *Service) buildStartUpOrder() error {
 			Selector:     selector,
 		}
 
-		if orderKey, found := ss.Annotations[StartupOrderAnnotationKey]; found {
+		if orderKey, found := ss.Annotations[startupOrderAnnotationKey]; found {
 			so, err := strconv.Atoi(orderKey)
 			if err != nil {
-				log.Warn("Unable to parse the int from the startup order key. Assigning to default group", "statefulset", ss.Name, "Namespace", ss.Namespace, "originalOrder", so, "key", StartupOrderAnnotationKey)
-				orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+				log.Warn("Unable to parse the int from the startup order key. Assigning to default group", "statefulset", ss.Name, "Namespace", ss.Namespace, "originalOrder", so, "key", startupOrderAnnotationKey)
+				orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 				continue
 			}
 
 			if so > 99 {
 				log.Warn("startUpOrder number can only be from 0 to 99. Assigning to default group", "statefulset", ss.Name, "Namespace", ss.Namespace, "originalOrder", so)
-				orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+				orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 				continue
 			}
 
@@ -102,7 +102,7 @@ func (s *Service) buildStartUpOrder() error {
 			continue
 		}
 		// Assign to the default group which starts up last if not set
-		orders[DefaultStartUpGroup] = append(orders[DefaultStartUpGroup], res)
+		orders[defaultStartUpGroup] = append(orders[defaultStartUpGroup], res)
 	}
 
 	log.Debug("Completed building startUpOrder", "orders", orders)

--- a/internal/service/startupOrder_test.go
+++ b/internal/service/startupOrder_test.go
@@ -34,7 +34,7 @@ func Test_BuildStartUpOrder(t *testing.T) {
 								Name:      "nginx",
 								Namespace: "web",
 								Annotations: map[string]string{
-									StartupOrderAnnotationKey: "1",
+									startupOrderAnnotationKey: "1",
 								},
 							},
 							Spec: v1.DeploymentSpec{
@@ -49,7 +49,7 @@ func Test_BuildStartUpOrder(t *testing.T) {
 								Name:      "mongodb",
 								Namespace: "database",
 								Annotations: map[string]string{
-									StartupOrderAnnotationKey: "0",
+									startupOrderAnnotationKey: "0",
 								},
 							},
 							Spec: v1.StatefulSetSpec{
@@ -87,7 +87,7 @@ func Test_BuildStartUpOrder(t *testing.T) {
 								Name:      "mongodb",
 								Namespace: "database",
 								Annotations: map[string]string{
-									StartupOrderAnnotationKey: "0",
+									startupOrderAnnotationKey: "0",
 								},
 							},
 							Spec: v1.StatefulSetSpec{

--- a/manifests/cronjob.yaml
+++ b/manifests/cronjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: active-cronjob
+spec:
+  schedule: "0 0 * * *"  # Runs daily at midnight
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: hello
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - echo "Hello from active cronjob"
+          restartPolicy: OnFailure
+  suspend: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: suspended-cronjob
+spec:
+  schedule: "0 0 * * *"  # Also scheduled daily at midnight
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: hello
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - echo "Hello from suspended cronjob"
+          restartPolicy: OnFailure
+  suspend: true
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: eks-env-scaledown
+
+  # This label should exclude the Cronjob from being managed
+  labels:
+    app: "eks-env-scaledown"
+
+spec:
+  schedule: "0 0 * * *"  # Also scheduled daily at midnight
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: eks-env-scaledown
+              image: busybox
+              args:
+                - /bin/sh
+                - -c
+                - echo "Hello from eks-env-scaledown"
+          restartPolicy: OnFailure
+  suspend: false


### PR DESCRIPTION
- Support for optionally disabling all CronJobs in the cluster during the scale down. Excludes the app label of the CronJob managing this app. Defaults to true
- Update some constants so they are not exported, as they aren't required outside of the package