### PR TITLE
Do not iterate through namespaces

### DIFF
--- a/internal/service/cronjob.go
+++ b/internal/service/cronjob.go
@@ -16,57 +16,51 @@ func (s *Service) updateCronJobs() error {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
 	defer cancelCtx()
 
-	namespaces, err := s.conf.K8sClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	cjs, err := s.conf.K8sClient.BatchV1().CronJobs("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing namespaces: %w", err)
+		return fmt.Errorf("listing CronJobs: %w", err)
 	}
-	for _, ns := range namespaces.Items {
-		cjs, err := s.conf.K8sClient.BatchV1().CronJobs(ns.Name).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("listing CronJobs in Namespace %s: %w", ns.Name, err)
-		}
 
-		for _, cj := range cjs.Items {
-			retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				result, getErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Get(ctx, cj.Name, metav1.GetOptions{})
-				if getErr != nil {
-					return getErr
-				}
+	for _, cj := range cjs.Items {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			result, getErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Get(ctx, cj.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
 
-				if appNameLabel, found := result.Labels["app"]; found && appNameLabel == cronJobAppName {
-					log.Debug("Skipping CronJob as it matches the app label which manages this app", "CronJob", cj.Name, "namespace", cj.Namespace)
+			if appNameLabel, found := result.Labels["app"]; found && appNameLabel == cronJobAppName {
+				log.Debug("Skipping CronJob as it matches the app label which manages this app", "CronJob", cj.Name, "namespace", cj.Namespace)
+				return nil
+			}
+
+			if result.Annotations == nil {
+				result.Annotations = make(map[string]string)
+			}
+
+			// Do not scale up anything that was previously scaled down
+			if s.conf.Action == config.ScaleUp {
+				if value, found := result.Annotations[cronJobWasDisabledAnnotationKey]; found && value == "yes" {
+					log.Warn("CronJob was previously disabled. Skipping", "CronJob", cj.Name, "namespace", cj.Namespace)
 					return nil
 				}
-
-				// Do not scale up anything that was previously scaled down
-				if s.conf.Action == config.ScaleUp {
-					if value, found := result.Annotations[cronJobWasDisabledAnnotationKey]; found && value == "yes" {
-						log.Warn("CronJob was previously disabled. Skipping", "CronJob", cj.Name, "namespace", cj.Namespace)
-						return nil
-					}
-					result.Spec.Suspend = boolPtr(false)
-				}
-
-				if s.conf.Action == config.ScaleDown {
-					if *result.Spec.Suspend == true {
-						log.Warn("CronJob is already disabled. Setting annotation for scaleup run", "CronJob", cj.Name, "namespace", cj.Namespace)
-						if result.Annotations == nil {
-							result.Annotations = make(map[string]string)
-						}
-						result.Annotations[cronJobWasDisabledAnnotationKey] = "yes"
-					}
-
-					result.Spec.Suspend = boolPtr(true)
-				}
-
-				result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
-
-				_, updateErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Update(ctx, result, metav1.UpdateOptions{})
-				return updateErr
-			})
-			if retryErr != nil {
-				return fmt.Errorf("updating CronJob %s in namespace %s: %w", cj.Name, cj.Namespace, err)
+				result.Spec.Suspend = boolPtr(false)
 			}
+
+			if s.conf.Action == config.ScaleDown {
+				if *result.Spec.Suspend == true {
+					log.Warn("CronJob is already disabled. Setting annotation for scaleup run", "CronJob", cj.Name, "namespace", cj.Namespace)
+					result.Annotations[cronJobWasDisabledAnnotationKey] = "yes"
+				}
+				result.Spec.Suspend = boolPtr(true)
+			}
+
+			result.Annotations[updatedAtAnnotationKey] = time.Now().Format(time.RFC3339)
+
+			_, updateErr := s.conf.K8sClient.BatchV1().CronJobs(cj.Namespace).Update(ctx, result, metav1.UpdateOptions{})
+			return updateErr
+		})
+		if retryErr != nil {
+			return fmt.Errorf("updating CronJob %s in namespace %s: %w", cj.Name, cj.Namespace, err)
 		}
 	}
 

--- a/internal/service/scaledown.go
+++ b/internal/service/scaledown.go
@@ -149,21 +149,15 @@ func (s *Service) terminateStandalonePods() error {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), timeout)
 	defer cancelCtx()
 
-	namespaces, err := s.conf.K8sClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	pods, err := s.conf.K8sClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing namespaces: %w", err)
+		return fmt.Errorf("listing pods: %w", err)
 	}
-	for _, ns := range namespaces.Items {
-		pods, err := s.conf.K8sClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("listing pods in Namespace %s: %w", ns.Name, err)
-		}
 
-		for _, pod := range pods.Items {
-			log.Debug("Terminating remaining pod", "pod", pod.Name, "Namespace", pod.Namespace)
-			if err = s.conf.K8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-				return fmt.Errorf("deleting pod %s in Namespace %s: %w", pod.Name, pod.Namespace, err)
-			}
+	for _, pod := range pods.Items {
+		log.Debug("Terminating remaining pod", "pod", pod.Name, "Namespace", pod.Namespace)
+		if err = s.conf.K8sClient.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("deleting pod %s in Namespace %s: %w", pod.Name, pod.Namespace, err)
 		}
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -60,13 +60,6 @@ func (s *Service) Run() error {
 func (s *Service) envScaleUp() error {
 	log.Info("Scaling environment up")
 
-	if s.conf.SuspendCronJob {
-		log.Info("Enabling all CronJobs except for the ones which manage this app or were previously disabled", "AppLabel", cronJobAppName)
-		if err := s.updateCronJobs(); err != nil {
-			return fmt.Errorf("re-enabling CronJobs: %w", err)
-		}
-	}
-
 	if err := s.buildStartUpOrder(); err != nil {
 		return fmt.Errorf("building startup order: %w", err)
 	}
@@ -83,6 +76,13 @@ func (s *Service) envScaleUp() error {
 		log.Info("Scaling up group", "group", order)
 		if err := s.scaleUpGroup(order); err != nil {
 			return fmt.Errorf("scaling up group %d: %w", order, err)
+		}
+	}
+
+	if s.conf.SuspendCronJob {
+		log.Info("Enabling all CronJobs except for the ones which manage this app or were previously disabled", "AppLabel", cronJobAppName)
+		if err := s.updateCronJobs(); err != nil {
+			return fmt.Errorf("re-enabling CronJobs: %w", err)
 		}
 	}
 


### PR DESCRIPTION
- List through resources directly rather than iterating through namespaces
- On scale up only re-enable the CronJobs after the deployment/statefulset groups have been brought back online