### PR TITLE
Add image build pipeline with semver releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,18 @@
+# CI pipeline. Runs on every branch push (not on tags):
+#   1. test-and-lint        - run the unit tests and golangci-lint.
+#   2. version              - decide the image tag. On main (only ever updated via a PR merge) the
+#                             next semver is calculated from the conventional commits since the last
+#                             tag (feat -> minor, fix -> patch, breaking -> major, otherwise patch)
+#                             and that git tag is pushed. On any other branch the long git SHA is used.
+#   3. build-and-push-image - build the multi-arch (amd64/arm64) image and push it to ECR, tagged with
+#                             the semver on main or the git SHA on other branches.
 name: CI
-on: push
+
+on:
+  push:
+    # All branches, but not tags — stops the auto-pushed semver tag from re-triggering this workflow
+    branches:
+      - '**'
 
 jobs:
   test-and-lint:
@@ -23,10 +36,44 @@ jobs:
         with:
           version: v2.12.2
 
-  build-and-push-image:
-    # Publish only from main, and only once tests + lint have passed
+  version:
     needs: test-and-lint
-    #if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    # Required to push the git tag (main only)
+    permissions:
+      contents: write
+
+    outputs:
+      image_tag: ${{ steps.image-tag.outputs.image_tag }}
+
+    steps:
+      - name: Clone git repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history + tags so the next semver can be calculated
+
+      # On main, derive the next semver from the conventional commits since the last tag and push it
+      - name: Calculate and push semver tag
+        id: semver
+        if: github.ref == 'refs/heads/main'
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+
+      # main -> the new semver tag, every other branch -> the long git SHA
+      - name: Determine image tag
+        id: image-tag
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "image_tag=${{ steps.semver.outputs.new_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-push-image:
+    needs: version
     runs-on: ubuntu-latest
 
     # Required for OIDC federation with AWS
@@ -66,4 +113,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPOSITORY }}:${{ needs.version.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 
 jobs:
-  unit-tests:
+  test-and-lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,3 +23,47 @@ jobs:
         with:
           version: v2.12.2
 
+  build-and-push-image:
+    # Publish only from main, and only once tests + lint have passed
+    needs: test-and-lint
+    #if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    # Required for OIDC federation with AWS
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      AWS_ACCOUNT_ID: "077439031059"
+      AWS_REGION: eu-west-2
+      IAM_ROLE: GithubActionsECRAndBuildArtefacts
+      ECR_REPOSITORY: eks-env-scaledown
+
+    steps:
+      - name: Clone git repo
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # QEMU enables emulating the arm64 platform on the amd64 runner
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPOSITORY }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       contents: read
 
     env:
-      AWS_ACCOUNT_ID: "077439031059"
+      AWS_ACCOUNT_ID: "633681147894"
       AWS_REGION: eu-west-2
-      IAM_ROLE: GithubActionsECRAndBuildArtefacts
+      IAM_ROLE: "github-actions-oidc"
       ECR_REPOSITORY: eks-env-scaledown
 
     steps:

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,19 @@ make test
 make cover
 ```
 
+## CI & Releases
+
+CI runs via GitHub Actions ([`.github/workflows/ci.yml`](./.github/workflows/ci.yml)) on every branch push:
+
+1. **Test & lint** - runs the unit tests and `golangci-lint`.
+2. **Version** - on feature branches the long git SHA is used as the image tag. On `main` (only ever
+   updated via a PR merge) the next [semantic version](https://semver.org/) is calculated automatically
+   from the [Conventional Commits](https://www.conventionalcommits.org/) since the last tag
+   (`feat` -> minor, `fix` -> patch, a breaking change -> major, anything else -> patch) and the new git
+   tag is pushed.
+3. **Build & push** - the multi-arch (`amd64`/`arm64`) Docker image is built and pushed to ECR, tagged
+   with the semver on `main` or the git SHA on other branches. AWS authentication uses an OIDC IAM role.
+
 ## Startup/Shutdown ordering
 
 You can define a startup order to `Deployments` and `Statefulsets` which will determine the startup order (lowest -> highest)


### PR DESCRIPTION
## Summary

Adds a Docker image build/publish pipeline to CI and wires up automated SemVer releases.

**On every branch push:**
1. **test-and-lint** — unit tests + `golangci-lint`.
2. **version** — determines the image tag (long git SHA on feature branches).
3. **build-and-push-image** — builds the multi-arch (`amd64`/`arm64`) image and pushes it to ECR. AWS auth is via an OIDC IAM role (region `eu-west-2`).

**On `main` (only updated via PR merge):**
- The `version` job computes the next SemVer from the [Conventional Commits](https://www.conventionalcommits.org/) since the last tag (`feat`→minor, `fix`→patch, breaking→major, otherwise patch) using `mathieudutour/github-tag-action@v6.2`, and pushes that git tag.
- The image is built and pushed tagged with the SemVer instead of the SHA.

## Notes
- The `push` trigger is scoped to `branches: ['**']` so the auto-pushed tag can't re-trigger the workflow.
- All actions pinned to their latest stable major (checkout v6, configure-aws-credentials v6, amazon-ecr-login v2, setup-qemu v4, setup-buildx v4, build-push v7).
- Key AWS details (account ID, region, role, ECR repo) are extracted into job-level env vars.
- The `version` job needs `contents: write` to push the tag; the build job uses `id-token: write` + `contents: read` for OIDC.
- Pipeline behaviour is documented in a header comment in the workflow and a new **CI & Releases** section in the readme.

## Requirements to go green
- Repo Actions workflow permissions must allow the `GITHUB_TOKEN` to push tags.
- The ECR repository `eks-env-scaledown` and the OIDC IAM role must exist.

## Testing
- `ci.yml` validated as well-formed YAML; jobs: `test-and-lint`, `version`, `build-and-push-image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)