### PR TITLE
fix: prevent client-go rate limiter exhaustion during ScaleUp

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,18 @@ func newK8sClients() (*kubernetes.Clientset, *dynamic.DynamicClient, error) {
 		}
 	}
 
+	// Raise the client-go local rate limits above the conservative defaults
+	// (QPS=5, Burst=10). Scale-up polls every resource in a startup group every
+	// couple of seconds while waiting for pods to become ready, on top of the
+	// cluster-wide List and per-resource Update calls. A group of a few dozen
+	// resources easily exceeds the default sustained QPS, so client-go throttles
+	// the requests locally (independently of any server-side throttling) and the
+	// backlog can grow until it exceeds the readiness loop's context deadline.
+	// QPS=50/Burst=100 comfortably covers polling ~100 resources every 2s with
+	// headroom for the initial burst where a whole group is polled on one tick.
+	config.QPS = 50
+	config.Burst = 100
+
 	client, err = kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating K8s client: %w", err)

--- a/internal/service/scaleup.go
+++ b/internal/service/scaleup.go
@@ -118,11 +118,20 @@ func (s *Service) waitForPodsReady(resources []*k8sResource) error {
 			}
 
 			for _, r := range resources {
+				// Skip resources already confirmed ready so we stop re-Getting them
+				// on every tick. Each tick otherwise polls every resource in the group,
+				// which is a sustained load on the client's local rate limiter; as more
+				// resources become ready the per-tick call count shrinks toward zero,
+				// keeping the rate limiter's backlog bounded rather than growing until
+				// it exceeds the context deadline.
+				if r.podsUpdatedAndReady {
+					continue
+				}
 				if r.ResourceType == resourceTypeDeployment {
 					log.Debug("Checking if pods are updated and ready", "type", r.ResourceType, "resource", r.Name, "Namespace", r.Namespace)
 					deployment, err := s.conf.K8sClient.AppsV1().Deployments(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
 					if err != nil {
-						return fmt.Errorf("getting deloyment %s in Namespace %s: %w", r.Name, r.Namespace, err)
+						return fmt.Errorf("getting deployment %s in Namespace %s: %w", r.Name, r.Namespace, err)
 					}
 					// Spec.Replicas is an optional pointer; the API server defaults an unset value to 1
 					desired := int32(1)


### PR DESCRIPTION
## Summary

During `ScaleUp`, the readiness loop polled **every** resource in a startup group on every tick — forever — even after a resource had already been marked ready. For a group of a few dozen resources, that sustained request rate exceeds client-go's conservative default local rate limit (QPS=5, Burst=10), so the client throttles the calls itself (independently of any server-side throttling) and the backlog grows until it exceeds the readiness loop's context deadline, failing the run even when the polled workloads are perfectly healthy.

## Changes

1. **`waitForPodsReady`** now skips resources whose `podsUpdatedAndReady` flag is already set, so the per-tick call count shrinks toward zero as the group comes up and the rate limiter backlog stays bounded (covers both the deployment and statefulset branches).
2. **`newK8sClients`** now sets `QPS=50` / `Burst=100` on the shared `rest.Config` (used by both the typed and dynamic clients), giving ample headroom for polling several dozen resources every couple of seconds with margin for the initial burst where a whole group is polled on one tick.
3. Fix the `"deloyment"` → `"deployment"` typo in the readiness-poll error string.

## Testing

- `go build ./...` — passes
- `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)